### PR TITLE
Added some flexibility

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,7 +24,8 @@ module.exports = function(grunt) {
     svn_tag: {
       options: {
         'dry-run': true,
-        'commitMessage': 'Tag project-{%= version %}'
+        'commitMessage': 'Tag project-v{%= version %}',
+        'tag': 'project-v{%= version %}'
       }
     }
   });

--- a/tasks/svn_tag.js
+++ b/tasks/svn_tag.js
@@ -20,8 +20,9 @@ module.exports = function(grunt) {
 
     var info,
         options = this.options({
-          'commitMessage': 'admin: Tag for release ({%= version %})',
-          'dry-run': false
+          'commitMessage': 'admin: Tag for release ({%= version %})'
+          , 'tag': 'v{%= version %}'
+          , 'dry-run': false
         });
 
     try {
@@ -37,9 +38,12 @@ module.exports = function(grunt) {
     }
 
     var packageJson =  grunt.file.readJSON(packageJsonLoc)
-      , projectVersion = 'v' + packageJson.version
+      , projectVersion = packageJson.version
       , fromURL = info.url
-      , toURL = info.repositoryRoot + '/tags/' + projectVersion
+      , tagName = processTemplate(options.tag, {
+            version: projectVersion
+        })
+      , toURL = info.repositoryRoot + '/tags/' + tagName
       , commitMessage = processTemplate(options.commitMessage, {
           version: projectVersion
         })


### PR DESCRIPTION
feature: works from any sub-directory
chore: handles exception if the tasks is executed outside of an svn directory
feature: Configurable commit message
feature: Configurable tag name
