### PR TITLE
fix: fixed "branches" or "trunk" logic when your repo structure happens to contain one of those words

### DIFF
--- a/tasks/svn_tag.js
+++ b/tasks/svn_tag.js
@@ -88,7 +88,7 @@ module.exports = function(grunt) {
     try {
       var _svnInfo = svnInfo.sync()
         , path = _svnInfo.relativeUrl ? _svnInfo.relativeUrl : _svnInfo.url;
-      path.split('/').every(function(part, ix, arr) {
+      path.split('/').reverse().every(function(part, ix, arr) {
         part = part.toLowerCase();
         if(part === 'trunk') {
           fromPath = '/trunk/';


### PR DESCRIPTION
If your repository path happens to have the word "branches" in it that
is not part of the project structure (.../repo/branches/north/projectA/trunk....) the source url for the tag
operation gets out of whack; a simple fix is to search for the word from the bottom up.